### PR TITLE
Add SAPCategory column to SubmittedRawData model

### DIFF
--- a/models/EmployeeHours/SubmittedRawData.js
+++ b/models/EmployeeHours/SubmittedRawData.js
@@ -18,7 +18,7 @@ const createSubmittedRawDataModel = (dbInstance) => {
         type: DataTypes.STRING,
       },
       Description: {
-        type: DataTypes.STRING,
+        type: DataTypes.STRING, //remove this later - replaced with SAP Category
       },
       NumHours: {
         type: DataTypes.FLOAT,
@@ -49,6 +49,9 @@ const createSubmittedRawDataModel = (dbInstance) => {
       Discarded: {
         type: DataTypes.BOOLEAN,
       },
+      SAPCategory: {
+        type: DataTypes.INTEGER,
+      }
     },
     {
       timestamps: false,


### PR DESCRIPTION
As per Kyle's request, we are adding a dropdown for Internal Job Name (aka SAPCategory) for the shop employees to use for their entries. I added a column for SAPCategory to handle this. It will be used going forward instead of Description, but we are keeping the Description column since there are many old entries that have used it, and this data will be displayed for employees on their SeeSubmittedHours page.